### PR TITLE
Add Jest and unit tests for getMoodStats

### DIFF
--- a/__tests__/getMoodStats.test.ts
+++ b/__tests__/getMoodStats.test.ts
@@ -1,0 +1,65 @@
+import { getMoodStats } from '../src/lib/supabase/queries';
+import { Mood } from '../src/lib/supabase/types';
+
+describe('getMoodStats', () => {
+  const createEntry = (date: string, score: number): Mood => ({
+    id: date,
+    user_id: 'u',
+    mood_score: score,
+    energy_score: 0,
+    anxiety_score: 0,
+    notes: '',
+    activities: [],
+    triggers: [],
+    date,
+    created_at: date,
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('detects an upward trend', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-06-04'));
+    const entries = [
+      createEntry('2024-06-04', 2),
+      createEntry('2024-06-03', 2),
+      createEntry('2024-06-02', 4),
+      createEntry('2024-06-01', 4),
+    ];
+    jest.spyOn(require('../src/lib/supabase/queries'), 'getMoodEntries').mockResolvedValue(entries);
+
+    const stats = await getMoodStats('u');
+    expect(stats.trend).toBe('up');
+    expect(stats.totalEntries).toBe(4);
+  });
+
+  it('detects a downward trend', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-06-04'));
+    const entries = [
+      createEntry('2024-06-04', 4),
+      createEntry('2024-06-03', 4),
+      createEntry('2024-06-02', 2),
+      createEntry('2024-06-01', 2),
+    ];
+    jest.spyOn(require('../src/lib/supabase/queries'), 'getMoodEntries').mockResolvedValue(entries);
+
+    const stats = await getMoodStats('u');
+    expect(stats.trend).toBe('down');
+  });
+
+  it('detects a stable trend', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-06-04'));
+    const entries = [
+      createEntry('2024-06-04', 3),
+      createEntry('2024-06-03', 3),
+      createEntry('2024-06-02', 3),
+      createEntry('2024-06-01', 3),
+    ];
+    jest.spyOn(require('../src/lib/supabase/queries'), 'getMoodEntries').mockResolvedValue(entries);
+
+    const stats = await getMoodStats('u');
+    expect(stats.trend).toBe('stable');
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(test).[jt]s?(x)'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@daily-co/daily-js": "^0.80.0",
@@ -53,6 +54,9 @@
     "eslint-config-next": "15.3.3",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "@types/jest": "^29.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest config and test script
- implement unit tests for `getMoodStats`
- configure `ts-jest` preset

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684868f5d6a0832b9c104405d81c9911